### PR TITLE
Remove all created resources in deprovision

### DIFF
--- a/roles/deprovision-keycloak-apb/tasks/main.yml
+++ b/roles/deprovision-keycloak-apb/tasks/main.yml
@@ -4,21 +4,40 @@
     namespace: '{{ namespace }}'
     state: absent
 
-- name: delete service
+- name: delete services
   k8s_v1_service:
-    name: keycloak
+    name: '{{ item }}'
     namespace: '{{ namespace }}'
     state: absent
-
-- name: delete deployment config
-  openshift_v1_deployment_config:
-    name: keycloak
-    namespace: '{{ namespace }}'
-    state: absent
-
-- 
-  name: delete secrets
-  command: oc delete secret {{ item }} -n {{namespace}}
   with_items:
-    - keycloak
+  - keycloak
+  - postgres
+  - keycloak-metrics
 
+- name: delete deployment configs
+  openshift_v1_deployment_config:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
+  with_items:
+  - keycloak
+  - postgres
+  - keycloak-metrics
+
+- name: delete secrets
+  k8s_v1_secret:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
+  with_items:
+  - keycloak
+  - keycloak-postgres
+
+- name: delete persistent volume claims
+  k8s_v1_persistent_volume_claim:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
+  with_items:
+  - keycloak-metrics
+  - postgres


### PR DESCRIPTION
Currently we only delete the Keycloak resources that are created
during provisioning. However, postgres and keycloak metrics are
also created and each contain a number of different resources
(services, deployments, secrets etc.). This cleans up every
resource that is created during the Keycloak APB provisioning.