### PR TITLE
Use https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ c2VydmljZSB0aGUgY2xpZW50IGlzIGZvcgogICAgICB0eXBlOiBzdHJpbmcK"
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
+COPY vars /opt/ansible/vars
 RUN chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/playbooks/bind.yml
+++ b/playbooks/bind.yml
@@ -2,6 +2,8 @@
   hosts: localhost
   gather_facts: false
   connection: local
+  vars_files:
+  - /opt/ansible/vars/main.yml
   roles:
   - role: ansible.kubernetes-modules
     install_python_requirements: no

--- a/playbooks/deprovision.yml
+++ b/playbooks/deprovision.yml
@@ -2,6 +2,8 @@
   hosts: localhost
   gather_facts: false
   connection: local
+  vars_files:
+  - /opt/ansible/vars/main.yml
   roles:
   - role: ansible.kubernetes-modules
     install_python_requirements: no

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -2,6 +2,8 @@
   hosts: localhost
   gather_facts: false
   connection: local
+  vars_files:
+  - /opt/ansible/vars/main.yml
   roles:
   - role: ansible.kubernetes-modules
     install_python_requirements: no

--- a/playbooks/unbind.yml
+++ b/playbooks/unbind.yml
@@ -2,6 +2,8 @@
   hosts: localhost
   gather_facts: false
   connection: local
+  vars_files:
+  - /opt/ansible/vars/main.yml
   roles:
   - role: ansible.kubernetes-modules
     install_python_requirements: no

--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ _apb_provision_creds.ADMIN_NAME }}&password={{ _apb_provision_creds.ADMIN_PASSWORD }}&grant_type=password"
     validate_certs: no
@@ -27,7 +27,7 @@
 -
   name: "Create {{ service }}-bearer client in realm {{ namespace }}"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
     body: "{\"id\": \"{{ service}}-bearer\", \"secret\": \"{{ generated_password.stdout }}\",\"bearerOnly\":true}"
     validate_certs: no
@@ -39,7 +39,7 @@
 -
   name: Get installation details bearer
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ service}}-bearer/installation/providers/keycloak-oidc-keycloak-json"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ service}}-bearer/installation/providers/keycloak-oidc-keycloak-json"
     method: GET
     validate_certs: no
     headers:
@@ -54,6 +54,6 @@
       name: "keycloak-bearer"
       resource: "{{ service }}-bearer"
       bearer_installation: "{{ installation_bearer.content }}"
-      uri: "https://{{ keycloak_route.stdout }}"
+      uri: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}"
       client_id: "{{ generated_username.stdout }}"
       client_secret: "{{ generated_password.stdout }}"

--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "https://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ _apb_provision_creds.ADMIN_NAME }}&password={{ _apb_provision_creds.ADMIN_PASSWORD }}&grant_type=password"
     validate_certs: no
@@ -27,7 +27,7 @@
 -
   name: "Create {{ service }}-bearer client in realm {{ namespace }}"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
     body: "{\"id\": \"{{ service}}-bearer\", \"secret\": \"{{ generated_password.stdout }}\",\"bearerOnly\":true}"
     validate_certs: no
@@ -39,7 +39,7 @@
 -
   name: Get installation details bearer
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ service}}-bearer/installation/providers/keycloak-oidc-keycloak-json"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ service}}-bearer/installation/providers/keycloak-oidc-keycloak-json"
     method: GET
     validate_certs: no
     headers:
@@ -54,6 +54,6 @@
       name: "keycloak-bearer"
       resource: "{{ service }}-bearer"
       bearer_installation: "{{ installation_bearer.content }}"
-      uri: "http://{{ keycloak_route.stdout }}"
+      uri: "https://{{ keycloak_route.stdout }}"
       client_id: "{{ generated_username.stdout }}"
       client_secret: "{{ generated_password.stdout }}"

--- a/roles/bind-keycloak-apb/templates/bind.json.j2
+++ b/roles/bind-keycloak-apb/templates/bind.json.j2
@@ -1,0 +1,8 @@
+{
+  "name": "keycloak-bearer",
+  "resource": "{{ service_name }}-bearer",
+  "bearer_installation": "{{ installationbearer | regex_replace('(u\'|\')', '\\\"') | replace(': True', ': true') }}",
+  "uri": "https://{{ keycloak_route.stdout }}",
+  "client_id": "{{ generated_username.stdout }}",
+  "client_secret": "{{ generated_password.stdout }}"
+}

--- a/roles/bind-keycloak-apb/templates/bind.json.j2
+++ b/roles/bind-keycloak-apb/templates/bind.json.j2
@@ -1,8 +1,0 @@
-{
-  "name": "keycloak-bearer",
-  "resource": "{{ service_name }}-bearer",
-  "bearer_installation": "{{ installationbearer | regex_replace('(u\'|\')', '\\\"') | replace(': True', ': true') }}",
-  "uri": "https://{{ keycloak_route.stdout }}",
-  "client_id": "{{ generated_username.stdout }}",
-  "client_secret": "{{ generated_password.stdout }}"
-}

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -36,6 +36,8 @@
         value: '{{ ADMIN_PASSWORD }}'
       - name: KEYCLOAK_PROMETHEUS_EVENTS_DIR
         value: /opt/jboss/metrics
+      - name: PROXY_ADDRESS_FORWARDING
+        value: 'true'
       - name: POSTGRES_USER
         value_from:
           secret_key_ref:
@@ -140,6 +142,8 @@
       app: keycloak
       service: keycloak
       mobile: enabled
+    tls_termination: edge
+    tls_insecure_edge_termination_policy: Redirect
     to_name: keycloak
     spec_port_target_port: web
 
@@ -163,7 +167,7 @@
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "https://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ ADMIN_NAME }}&password={{ ADMIN_PASSWORD }}&grant_type=password"
     validate_certs: no
@@ -179,7 +183,7 @@
 
 - name: "Create {{ namespace }} realm"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms"
     method: POST
     body: "{{ lookup('file','/tmp/namespace_realm.json') }}"
     validate_certs: no
@@ -199,7 +203,7 @@
 
 - name: "Create UPS realm"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms"
     method: POST
     body: "{{ lookup('file','/tmp/push_realm.json') }}"
     validate_certs: no
@@ -221,7 +225,7 @@
 -
   name: "Create {{ generated_username.stdout }} client in realm {{ namespace }}"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
     body: "{\"id\": \"{{ generated_username.stdout }}\", \"secret\": \"{{ generated_password.stdout }}\", \"redirectUris\":[\"http://localhost:*\"], \"webOrigins\":[\"http://localhost:8100\"] }"
     validate_certs: no
@@ -233,7 +237,7 @@
 -
   name: "Create {{ generated_username.stdout }}-bearer client in realm {{ namespace }}"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
     body: "{\"id\": \"{{ generated_username.stdout }}-bearer\", \"secret\": \"{{ generated_password.stdout }}\",\"bearerOnly\":true}"
     validate_certs: no
@@ -245,7 +249,7 @@
 -
   name: Get installation details bearer
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}-bearer/installation/providers/keycloak-oidc-keycloak-json"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}-bearer/installation/providers/keycloak-oidc-keycloak-json"
     method: GET
     validate_certs: no
     headers:
@@ -257,7 +261,7 @@
 -
   name: Get installation details
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}/installation/providers/keycloak-oidc-keycloak-json"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}/installation/providers/keycloak-oidc-keycloak-json"
     method: GET
     validate_certs: no
     headers:

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -134,7 +134,19 @@
       port: 80
       target_port: 8081
 
-- name: create keycloak route
+- name: create keycloak http route
+  openshift_v1_route:
+    name: keycloak
+    namespace: '{{ namespace }}'
+    labels:
+      app: keycloak
+      service: keycloak
+      mobile: enabled
+    to_name: keycloak
+    spec_port_target_port: web
+  when: keycloak_protocol == 'http'
+
+- name: create keycloak https route
   openshift_v1_route:
     name: keycloak
     namespace: '{{ namespace }}'
@@ -146,6 +158,7 @@
     tls_insecure_edge_termination_policy: Redirect
     to_name: keycloak
     spec_port_target_port: web
+  when: keycloak_protocol == 'https'
 
 - name: "Retrieve route to keycloak"
   shell: "oc get routes keycloak -n '{{ namespace }}' | grep -v NAME | awk '{print $2}'"
@@ -167,7 +180,7 @@
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ ADMIN_NAME }}&password={{ ADMIN_PASSWORD }}&grant_type=password"
     validate_certs: no
@@ -183,7 +196,7 @@
 
 - name: "Create {{ namespace }} realm"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms"
     method: POST
     body: "{{ lookup('file','/tmp/namespace_realm.json') }}"
     validate_certs: no
@@ -203,7 +216,7 @@
 
 - name: "Create UPS realm"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms"
     method: POST
     body: "{{ lookup('file','/tmp/push_realm.json') }}"
     validate_certs: no
@@ -225,7 +238,7 @@
 -
   name: "Create {{ generated_username.stdout }} client in realm {{ namespace }}"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
     body: "{\"id\": \"{{ generated_username.stdout }}\", \"secret\": \"{{ generated_password.stdout }}\", \"redirectUris\":[\"http://localhost:*\"], \"webOrigins\":[\"http://localhost:8100\"] }"
     validate_certs: no
@@ -237,7 +250,7 @@
 -
   name: "Create {{ generated_username.stdout }}-bearer client in realm {{ namespace }}"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
     body: "{\"id\": \"{{ generated_username.stdout }}-bearer\", \"secret\": \"{{ generated_password.stdout }}\",\"bearerOnly\":true}"
     validate_certs: no
@@ -249,7 +262,7 @@
 -
   name: Get installation details bearer
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}-bearer/installation/providers/keycloak-oidc-keycloak-json"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}-bearer/installation/providers/keycloak-oidc-keycloak-json"
     method: GET
     validate_certs: no
     headers:
@@ -261,7 +274,7 @@
 -
   name: Get installation details
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}/installation/providers/keycloak-oidc-keycloak-json"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ generated_username.stdout }}/installation/providers/keycloak-oidc-keycloak-json"
     method: GET
     validate_certs: no
     headers:

--- a/roles/provision-keycloak-apb/templates/secret.yml.j2
+++ b/roles/provision-keycloak-apb/templates/secret.yml.j2
@@ -12,7 +12,7 @@ stringData:
   name: keycloak
   admin_username: {{ ADMIN_NAME }}
   admin_password: {{ ADMIN_PASSWORD }}
-  uri: http://{{ keycloak_route.stdout }}
+  uri: https://{{ keycloak_route.stdout }}
   bearer_client_id: {{ generated_username.stdout }}-bearer
   bearer_client_secret: {{ generated_password.stdout }}
   bearer_installation: "{{ installationbearer | regex_replace('(u\'|\')', '\\\"') | replace(': True', ': true') }}"

--- a/roles/provision-keycloak-apb/templates/secret.yml.j2
+++ b/roles/provision-keycloak-apb/templates/secret.yml.j2
@@ -12,7 +12,7 @@ stringData:
   name: keycloak
   admin_username: {{ ADMIN_NAME }}
   admin_password: {{ ADMIN_PASSWORD }}
-  uri: https://{{ keycloak_route.stdout }}
+  uri: {{ keycloak_protocol }}://{{ keycloak_route.stdout }}
   bearer_client_id: {{ generated_username.stdout }}-bearer
   bearer_client_secret: {{ generated_password.stdout }}
   bearer_installation: "{{ installationbearer | regex_replace('(u\'|\')', '\\\"') | replace(': True', ': true') }}"

--- a/roles/unbind-keycloak-apb/tasks/main.yml
+++ b/roles/unbind-keycloak-apb/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ _apb_provision_creds.ADMIN_NAME }}&password={{
       _apb_provision_creds.ADMIN_PASSWORD }}&grant_type=password"
@@ -23,7 +23,7 @@
 -
   name: delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}
   uri:
-    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ _apb_bind_creds.resource }}"
+    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ _apb_bind_creds.resource }}"
     method: DELETE
     validate_certs: no
     headers:

--- a/roles/unbind-keycloak-apb/tasks/main.yml
+++ b/roles/unbind-keycloak-apb/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "https://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ _apb_provision_creds.ADMIN_NAME }}&password={{
       _apb_provision_creds.ADMIN_PASSWORD }}&grant_type=password"
@@ -23,7 +23,7 @@
 -
   name: delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}
   uri:
-    url: "http://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ _apb_bind_creds.resource }}"
+    url: "https://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ _apb_bind_creds.resource }}"
     method: DELETE
     validate_certs: no
     headers:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+# http or https.
+keycloak_protocol: https


### PR DESCRIPTION
Use https instead of http  

Verification steps:
* Provision the Keycloak service
* Ensure the route is https
* Ensure Keycloak is accessible
* Ensure bind and unbind continue to work correctly