### PR TITLE
[Do not merge] AEROGEAR-1774 Trust OpenShift cert

### DIFF
--- a/roles/provision-keycloak-apb/files/configure-keystore.sh
+++ b/roles/provision-keycloak-apb/files/configure-keystore.sh
@@ -1,0 +1,7 @@
+readonly keystore_dir=/opt/jboss/keycloak/keystore
+readonly keycloak_keystore=$keystore_dir/application.keystore
+readonly default_keystore=${JAVA_HOME}/jre/lib/security/cacerts
+readonly keycloak_store_password=${1:-changeit}
+
+keytool --noprompt -importkeystore -srckeystore ${default_keystore} -destkeystore ${keycloak_keystore} -srcstorepass changeit -deststorepass ${keycloak_store_password}
+keytool --noprompt -importcert -file ${keystore_dir}/cert.pem -storepass ${keycloak_store_password} -keystore $keycloak_keystore

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -1,3 +1,7 @@
+- name: generate truststore password
+  shell: head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo ''
+  register: gen_truststore_password
+
 - name: create persistent volume claim for metrics
   k8s_v1_persistent_volume_claim:
     name: keycloak-metrics
@@ -54,7 +58,7 @@
             name: '{{ postgres_secret_name }}'
             key: database-name
       - name: JAVA_OPTS
-        value: -Djavax.net.ssl.trustStore=/opt/jboss/keycloak/keystore/application.keystore -Djavax.net.ssl.trustStorePassword=changeit -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
+        value: -Djavax.net.ssl.trustStore=/opt/jboss/keycloak/keystore/application.keystore -Djavax.net.ssl.trustStorePassword={{ gen_truststore_password.stdout }} -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
       image: 'docker.io/jboss/keycloak-openshift:{{ keycloak_image_tag }}'
       name: keycloak
       ports:
@@ -184,7 +188,7 @@
   delay: 5
 
 - name: Retrieve OpenShift cluster certificate
-  shell: echo -n “” | openssl s_client -connect $KUBERNETES_PORT_443_TCP_ADDR:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/cert.pem
+  shell: echo -n "" | openssl s_client -connect $KUBERNETES_PORT_443_TCP_ADDR:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/cert.pem
 
 - copy:
     src: configure-keystore.sh
@@ -203,7 +207,7 @@
   until: copy_startup_script.rc == 0
 
 - name: Run configure keystore script
-  shell: oc exec --namespace {{ namespace }} {{ get_pods.stdout }} bash /opt/jboss/keycloak/keystore/configure-keystore.sh
+  shell: oc exec --namespace {{ namespace }} {{ get_pods.stdout }} bash /opt/jboss/keycloak/keystore/configure-keystore.sh {{ gen_truststore_password.stdout }}
 
 - name: "Generate keycloak auth token"
   uri:
@@ -340,3 +344,4 @@
     fields:
       ADMIN_NAME: "{{ ADMIN_NAME }}"
       ADMIN_PASSWORD: "{{ ADMIN_PASSWORD }}"
+      TRUSTSTORE_PASSWORD: "{{ gen_truststore_password.stdout }}"

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -53,6 +53,8 @@
           secret_key_ref:
             name: '{{ postgres_secret_name }}'
             key: database-name
+      - name: JAVA_OPTS
+        value: -Djavax.net.ssl.trustStore=/opt/jboss/keycloak/keystore/application.keystore -Djavax.net.ssl.trustStorePassword=changeit -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
       image: 'docker.io/jboss/keycloak-openshift:{{ keycloak_image_tag }}'
       name: keycloak
       ports:
@@ -65,6 +67,9 @@
       - mount_path: /opt/jboss/keycloak/providers/
         name: keycloak-metrics
         sub_path: providers/
+      - mount_path: /opt/jboss/keycloak/keystore/
+        name: keycloak-metrics
+        sub_path: keystore/
 
 - name: create metrics deployment config
   openshift_v1_deployment_config:
@@ -177,6 +182,28 @@
   retries: 60
   until: copy_jar.rc == 0
   delay: 5
+
+- name: Retrieve OpenShift cluster certificate
+  shell: echo -n “” | openssl s_client -connect $KUBERNETES_PORT_443_TCP_ADDR:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/cert.pem
+
+- copy:
+    src: configure-keystore.sh
+    dest: /tmp/configure-keystore.sh
+
+- name: Copy certificate into keystore directory
+  shell: oc cp /tmp/cert.pem {{ namespace }}/{{ get_pods.stdout }}:/opt/jboss/keycloak/keystore/cert.pem
+  register: copy_cert
+  retries: 60
+  until: copy_cert.rc == 0
+  delay: 5
+
+- name: Copy script into keystore directory
+  shell: oc cp /tmp/configure-keystore.sh {{ namespace }}/{{ get_pods.stdout }}:/opt/jboss/keycloak/keystore/
+  register: copy_startup_script
+  until: copy_startup_script.rc == 0
+
+- name: Run configure keystore script
+  shell: oc exec --namespace {{ namespace }} {{ get_pods.stdout }} bash /opt/jboss/keycloak/keystore/configure-keystore.sh
 
 - name: "Generate keycloak auth token"
   uri:


### PR DESCRIPTION
Currently Keycloak/OpenShift SSO will not work on a local development cluster. This is because of the self signed cert of the local OpenShift cluster.

This change obtains the cert for OpenShift and adds it to a trust store.