### PR TITLE
Added annotation for Prometheus

### DIFF
--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -65,6 +65,8 @@
   k8s_v1_service:
     name: keycloak
     namespace: '{{ namespace }}'
+    annotations:
+      org.aerogear.metrics/plain_endpoint:  /auth/realms/master/metrics
     labels:
       app: keycloak
       service: keycloak

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -66,6 +66,7 @@
     name: keycloak
     namespace: '{{ namespace }}'
     annotations:
+      # this only works with the custom JAR (SPI impl) https://github.com/aerogear/keycloak-metrics-spi
       org.aerogear.metrics/plain_endpoint:  /auth/realms/master/metrics
     labels:
       app: keycloak


### PR DESCRIPTION
Currently the Keycloak metrics are not discoverable by Prometheus. This is because the Keycloak service does not contain the org.aerogear.metrics/plain_endpoint annotation pointing at the Keycloak metrics endpoint.

The annotation was added so that when Prometheus is provisioned the Keycloak metrics are discoverable.
