### PR TITLE
Delete client only, when actually was created/bind before

### DIFF
--- a/roles/unbind-keycloak-apb/tasks/main.yml
+++ b/roles/unbind-keycloak-apb/tasks/main.yml
@@ -21,8 +21,9 @@
     verbosity: 2
 
 -
-  name: delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}
+  name: "delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}"
   uri:
+    when: _apb_bind_creds is defined
     url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ _apb_bind_creds.resource }}"
     method: DELETE
     validate_certs: no


### PR DESCRIPTION
See FH-4354

Steps to reproduce:
* create empty project
* select in Keycloak from the catalog
* create a binding
* wait until _fully_ provisioned (e.g. no _pending_ on the secrets/service etc)

Do nothing - do not bind it to some app etc.  Just remove the never used Keycloak service.

There will be a project for the `unbind`, and you will see something like:

```

TASK [unbind-keycloak-apb : delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}] ***
--
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: '_apb_bind_creds' is undefined\n\nThe error appears to have been in '/opt/ansible/roles/unbind-keycloak-apb/tasks/main.yml': line 24, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n-\n  name: delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: '_apb_bind_creds' is undefined"}
to retry, use: --limit @/opt/apb/actions/unbind.retry
PLAY RECAP *********************************************************************
 


```


Fix is to make this step only executable when the actual resource is really present 