### PR TITLE
AEROGEAR-1986 split up keycloak config into secret and non secret parts

### DIFF
--- a/roles/deprovision-keycloak-apb/tasks/main.yml
+++ b/roles/deprovision-keycloak-apb/tasks/main.yml
@@ -31,6 +31,14 @@
   - keycloak
   - keycloak-postgres
 
+- name: delete config maps
+  k8s_v1_config_map:
+    name: '{{ item }}'
+    namespace: '{{ namespace }}'
+    state: absent
+  with_items:
+  - keycloak
+
 - name: delete persistent volume claims
   k8s_v1_persistent_volume_claim:
     name: '{{ item }}'

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -1,3 +1,10 @@
+- name: Get the name of the service instance
+  shell: oc get serviceinstance --namespace={{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
+  register: service_instance_name
+
+- name: Label the service instance with the service name
+  shell: oc label serviceinstance '{{ service_instance_name.stdout }}' serviceName=keycloak --namespace={{ namespace }}
+
 - name: create persistent volume claim to copy the SPI provider
   k8s_v1_persistent_volume_claim:
     name: '{{ keycloak_pv_claim_name }}'

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -1,9 +1,11 @@
 - name: Get the name of the service instance
   shell: oc get serviceinstance --namespace={{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
+  when: _apb_service_instance_id is defined
   register: service_instance_name
 
 - name: Label the service instance with the service name
   shell: oc label serviceinstance '{{ service_instance_name.stdout }}' serviceName=keycloak --namespace={{ namespace }}
+  when: _apb_service_instance_id is defined
 
 - name: create persistent volume claim to copy the SPI provider
   k8s_v1_persistent_volume_claim:

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -223,16 +223,27 @@
 - set_fact: installation="{{ installation_text.stdout | from_json }}"
 - set_fact: installationbearer="{{ installation_bearer.content | from_json }}"
 
+- k8s_v1_secret:
+    name: keycloak
+    namespace: '{{ namespace }}'
+    labels:
+      name: keycloak
+      mobile: enabled
+      serviceName: keycloak
+    string_data:
+      admin_username: '{{ ADMIN_NAME }}'
+      admin_password: '{{ ADMIN_PASSWORD }}'
+
 - name: Create keycloak bearer client template
   template:
-    src: secret.yml.j2
-    dest: /tmp/secret.yaml
+    src: configmap.yml.j2
+    dest: /tmp/configmap.yaml
 
-- name: Create keycloak public client secret
-  shell: oc create -f /tmp/secret.yaml -n {{ namespace }}
+- name: Create keycloak public client config map
+  shell: oc create -f /tmp/configmap.yaml -n {{ namespace }}
 
-- name: delete secret template file
-  file: path=/tmp/secret.yaml state=absent
+- name: delete configmap template file
+  file: path=/tmp/configmap.yaml state=absent
 
 - name: encode admin user credentials
   asb_encode_binding:

--- a/roles/provision-keycloak-apb/templates/configmap.yml.j2
+++ b/roles/provision-keycloak-apb/templates/configmap.yml.j2
@@ -1,17 +1,15 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: '{{ keycloak_secret_name }}'
   namespace: {{ namespace }}
   labels:
-    name: keycloak
     mobile: enabled
-stringData:
+    serviceName: keycloak
+data:
   type: keycloak
   realm: {{namespace}}
   name: keycloak
-  admin_username: "{{ ADMIN_NAME }}"
-  admin_password: "{{ ADMIN_PASSWORD }}"
   uri: {{ keycloak_protocol }}://{{ keycloak_route.stdout }}
   bearer_client_id: {{ generated_username.stdout }}-bearer
   bearer_client_secret: {{ generated_password.stdout }}


### PR DESCRIPTION
Split up the keycloak config into secret and non secret parts where the non-secret parts are stored in a config map.

Based on this proposal: https://github.com/aerogear/proposals/blob/master/apbs/create-secret-and-configmap-during-provision.md#proposed-solution

To verify, checkout this branch and provision the apb. After everything is deployed, check that both, a config map and a secret with the name `keycloak` exist. The secret should only contain username and password. Delete the service instance. The config map and the secret should also be deleted.