### PR TITLE
Fix limitations with username and password

### DIFF
--- a/roles/provision-keycloak-apb/templates/secret.yml.j2
+++ b/roles/provision-keycloak-apb/templates/secret.yml.j2
@@ -10,8 +10,8 @@ stringData:
   type: keycloak
   realm: {{namespace}}
   name: keycloak
-  admin_username: {{ ADMIN_NAME }}
-  admin_password: {{ ADMIN_PASSWORD }}
+  admin_username: "{{ ADMIN_NAME }}"
+  admin_password: "{{ ADMIN_PASSWORD }}"
   uri: {{ keycloak_protocol }}://{{ keycloak_route.stdout }}
   bearer_client_id: {{ generated_username.stdout }}-bearer
   bearer_client_secret: {{ generated_password.stdout }}


### PR DESCRIPTION
Currently if a password of '123' is provided it will cause the JSON
parsing in the provision role to fail when creating the keycloak
public config and persisting it.

This change wraps the username and password variables in quotes to
ensure that these fields are treated as strings.