### PR TITLE
Adds small corrections to Keycloak dashboard that are missing from PR

### DIFF
--- a/roles/provision-keycloak-apb/files/keycloak-dashboard.json
+++ b/roles/provision-keycloak-apb/files/keycloak-dashboard.json
@@ -47,7 +47,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "panels": [
     {
@@ -100,7 +99,7 @@
       "rangeMaps": [
         {
           "from": "null",
-          "text": "N/A",
+          "text": "0",
           "to": "null"
         }
       ],
@@ -271,7 +270,7 @@
       "rangeMaps": [
         {
           "from": "null",
-          "text": "N/A",
+          "text": "0",
           "to": "null"
         }
       ],
@@ -510,7 +509,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -526,7 +525,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{provider}}",
+          "legendFormat": "{{error}}",
           "refId": "A"
         }
       ],
@@ -596,7 +595,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "percentage": false,
       "pointradius": 5,
       "points": false,


### PR DESCRIPTION
### Changes
* Removes conflicting and unnecessary `id` property from.
* `0` instead of `N/A` for counters where no data.
* Error type in *Login Errors*'s leyend instead of provider.
* Prevent charts from displaying gaps when there is null data. Display a connecting line instead.