### PR TITLE
Use public access type instead of confidential for client apps

### DIFF
--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -166,7 +166,7 @@
   uri:
     url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients"
     method: POST
-    body: "{\"id\": \"{{ generated_username.stdout }}\", \"secret\": \"{{ generated_password.stdout }}\", \"redirectUris\":[\"http://localhost:*\"], \"webOrigins\":[\"http://localhost:8100\"] }"
+    body: "{\"id\": \"{{ generated_username.stdout }}\", \"secret\": \"{{ generated_password.stdout }}\", \"redirectUris\":[\"http://localhost:*\"], \"webOrigins\":[\"http://localhost:8100\"], \"publicClient\": true }"
     validate_certs: no
     body_format: json
     headers:


### PR DESCRIPTION
@rachael-oregan Would you mind taking a quick look? Based on this comment, https://issues.jboss.org/browse/KEYCLOAK-3765?focusedCommentId=13312743&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13312743

Have tested with the Auth example app