### PR TITLE
Fixed test of metrics endpoint

### DIFF
--- a/roles/test-provision-apb/tasks/main.yml
+++ b/roles/test-provision-apb/tasks/main.yml
@@ -8,9 +8,6 @@
   register: webpage
   retries: 10
   delay: 20
-  failed_when:
-    - webpage.status == 403
-    - '"Welcome to Keycloak" not in webpage.content'
   until: '"Welcome to Keycloak" in webpage.content'
 
 - name: Check that the metrics endpoint works
@@ -21,7 +18,4 @@
   register: webpage
   retries: 10
   delay: 20
-  failed_when:
-    - webpage.status == 403
-    - '"kc_logged_in_users" not in webpage.content'
-  until: '"kc_logged_in_users" in webpage.content'
+  until: '"jvm_memory_bytes_used" in webpage.content'


### PR DESCRIPTION
I've noticed a strange behaviour of the "check for metrics endpoint" in [latest builds](https://jenkins-wendy.ci.feedhenry.org/job/AeroGearCatalog/job/keycloak-apb/job/master/26/console)

Apparently the metric `kc_logged_in_users` is no longer present in keycloak's metric endpoint.