### PR TITLE
add generic mobile enabled label

### DIFF
--- a/roles/provision-keycloak-apb/tasks/label-serviceinstance.yml
+++ b/roles/provision-keycloak-apb/tasks/label-serviceinstance.yml
@@ -6,3 +6,7 @@
 - name: Label the service instance with the service name
   shell: oc label serviceinstance '{{ service_instance_name.stdout }}' serviceName=keycloak --namespace={{ namespace }}
   when: _apb_service_instance_id is defined
+
+- name: Label the service instance with mobile enabled
+  shell: oc label serviceinstance '{{ service_instance_name.stdout }}' mobile=enabled --namespace={{ namespace }}
+  when: _apb_service_instance_id is defined  


### PR DESCRIPTION
This pr adds a generic label to allow the UI to find all serviceinstances created by mobile apbs