### PR TITLE
[AEROGEAR-1996] Update unbind playbook to deconfigure when shared

### DIFF
--- a/roles/unbind-keycloak-apb/tasks/main.yml
+++ b/roles/unbind-keycloak-apb/tasks/main.yml
@@ -1,12 +1,10 @@
-- 
-  name: "Retrieve route to keycloak"
-  shell: "oc get routes keycloak -n '{{ namespace }}' | grep -v NAME | awk '{print $2}'"
+- name: "Retrieve route to keycloak"
+  shell: "oc get configmaps/{{keycloak_service_name}} -n {{ namespace }} -o jsonpath='{.data.uri}'"
   register: keycloak_route
-- debug: msg="kc route = {{keycloak_route}}"
 
 - name: "Generate keycloak auth token"
   uri:
-    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    url: "{{ keycloak_route.stdout }}/auth/realms/master/protocol/openid-connect/token"
     method: POST
     body: "client_id=admin-cli&username={{ _apb_provision_creds.ADMIN_NAME }}&password={{
       _apb_provision_creds.ADMIN_PASSWORD }}&grant_type=password"
@@ -20,10 +18,11 @@
     var: keycloak_auth_response
     verbosity: 2
 
--
-  name: delete client {{ _apb_bind_creds.resource }} in realm {{ namespace }}
+- set_fact: KEYCLOAK_REALM={{ _apb_bind_creds.bearer_installation.realm}}
+
+- name: delete client {{ _apb_bind_creds.resource }} in realm {{ KEYCLOAK_REALM }}
   uri:
-    url: "{{ keycloak_protocol }}://{{ keycloak_route.stdout }}/auth/admin/realms/{{ namespace }}/clients/{{ _apb_bind_creds.resource }}"
+    url: "{{ keycloak_route.stdout }}/auth/admin/realms/{{ KEYCLOAK_REALM }}/clients/{{ _apb_bind_creds.client_id }}"
     method: DELETE
     validate_certs: no
     headers:


### PR DESCRIPTION
## Description
On unbind, it should connect to the remote keycloak server. It should remove the client bearer from the realm and the resource should be deleted in the local namespace.

## Related Notes
This PR is dependent on the changes from https://github.com/aerogearcatalog/keycloak-apb/pull/49
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-1996

## Test Cases
- Ensure that the client bearer is deleted from the Keycloak realm it was created in.
- Ensure that the resource from the local namespace is removed.
- Ensure that you can create another client bearer with the same name within the same Keycloak realm once removed.