### PR TITLE
Check if client exists before deleting

### DIFF
--- a/roles/deprovision-keycloak-apb/tasks/cleanup-keycloak.yml
+++ b/roles/deprovision-keycloak-apb/tasks/cleanup-keycloak.yml
@@ -47,6 +47,14 @@
     var: kc_auth_response
     verbosity: 2
 
+- name: Fail due to invalid credentials
+  fail: msg="Failed to get access token due to invalid credentials"
+  when: kc_auth_response.status == 401
+
+- name: Fail due to lack of authorization
+  fail: msg="Failed to get access token. The user {{ kcdev_username.stdout }} is unauthorized to perform this action"
+  when: kc_auth_response.status == 403
+
 - name: Get {{ kc_configmap_user.stdout }} and {{ kc_configmap_user.stdout }}-bearer clients in realm {{ kc_configmap_realm.stdout }}
   uri:
     url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/clients/{{ item }}"
@@ -56,7 +64,7 @@
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
     status_code: 200, 404
     return_content: yes
-  when: kc_auth_response.status != 503
+  when: kc_auth_response.status == 200
   register: kc_clients_get_response
   with_items:
     - "{{ kc_configmap_user.stdout }}"
@@ -71,7 +79,7 @@
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
     status_code: 204
     return_content: yes
-  when: kc_auth_response.status != 503 and item.status == 200
+  when: kc_auth_response.status == 200 and item.status == 200
   with_items:
     - "{{ kc_clients_get_response.results }}"
 
@@ -84,7 +92,7 @@
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
     status_code: 200, 404
     return_content: yes
-  when: kc_auth_response.status != 503
+  when: kc_auth_response.status == 200
   register: kc_users_get_response
   with_items:
     - "{{ kcdev_userid.stdout }}"
@@ -98,6 +106,6 @@
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
     status_code: 204
     return_content: yes
-  when: kc_auth_response.status != 503 and item.status == 200
+  when: kc_auth_response.status == 200 and item.status == 200
   with_items:
     - "{{ kc_users_get_response.results }}"

--- a/roles/deprovision-keycloak-apb/tasks/cleanup-keycloak.yml
+++ b/roles/deprovision-keycloak-apb/tasks/cleanup-keycloak.yml
@@ -47,29 +47,57 @@
     var: kc_auth_response
     verbosity: 2
 
-- name: Delete client {{ kc_configmap_user.stdout }} in realm {{ kc_configmap_realm.stdout }}
+- name: Get {{ kc_configmap_user.stdout }} and {{ kc_configmap_user.stdout }}-bearer clients in realm {{ kc_configmap_realm.stdout }}
   uri:
     url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/clients/{{ item }}"
-    method: DELETE
+    method: GET
     validate_certs: no
     headers:
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
-    status_code: 204
+    status_code: 200, 404
     return_content: yes
   when: kc_auth_response.status != 503
+  register: kc_clients_get_response
   with_items:
     - "{{ kc_configmap_user.stdout }}"
     - "{{ kc_configmap_user.stdout }}-bearer"
 
-- name: Delete {{ kcdev_username.stdout }} user in realm {{ kc_configmap_realm.stdout }}
+- name: Delete {{ kc_configmap_user.stdout }} in realm {{ kc_configmap_realm.stdout }}
   uri:
-    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/users/{{ item }}"
+    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/clients/{{ item.json.id }}"
     method: DELETE
     validate_certs: no
     headers:
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
     status_code: 204
     return_content: yes
+  when: kc_auth_response.status != 503 and item.status == 200
+  with_items:
+    - "{{ kc_clients_get_response.results }}"
+
+- name: Get {{ kcdev_username.stdout }} user in realm {{ kc_configmap_realm.stdout }}
+  uri:
+    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/users/{{ item }}"
+    method: GET
+    validate_certs: no
+    headers:
+      Authorization: "bearer {{ kc_auth_response.json.access_token }}"
+    status_code: 200, 404
+    return_content: yes
   when: kc_auth_response.status != 503
+  register: kc_users_get_response
   with_items:
     - "{{ kcdev_userid.stdout }}"
+
+- name: Delete {{ kcdev_username.stdout }} user in realm {{ kc_configmap_realm.stdout }}
+  uri:
+    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/users/{{ item.json.id }}"
+    method: DELETE
+    validate_certs: no
+    headers:
+      Authorization: "bearer {{ kc_auth_response.json.access_token }}"
+    status_code: 204
+    return_content: yes
+  when: kc_auth_response.status != 503 and item.status == 200
+  with_items:
+    - "{{ kc_users_get_response.results }}"

--- a/roles/deprovision-keycloak-apb/tasks/cleanup-keycloak.yml
+++ b/roles/deprovision-keycloak-apb/tasks/cleanup-keycloak.yml
@@ -55,57 +55,29 @@
   fail: msg="Failed to get access token. The user {{ kcdev_username.stdout }} is unauthorized to perform this action"
   when: kc_auth_response.status == 403
 
-- name: Get {{ kc_configmap_user.stdout }} and {{ kc_configmap_user.stdout }}-bearer clients in realm {{ kc_configmap_realm.stdout }}
+- name: Delete {{ kc_configmap_user.stdout }} in realm {{ kc_configmap_realm.stdout }}
   uri:
     url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/clients/{{ item }}"
-    method: GET
+    method: DELETE
     validate_certs: no
     headers:
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
-    status_code: 200, 404
+    status_code: 204, 404
     return_content: yes
   when: kc_auth_response.status == 200
-  register: kc_clients_get_response
   with_items:
     - "{{ kc_configmap_user.stdout }}"
     - "{{ kc_configmap_user.stdout }}-bearer"
 
-- name: Delete {{ kc_configmap_user.stdout }} in realm {{ kc_configmap_realm.stdout }}
-  uri:
-    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/clients/{{ item.json.id }}"
-    method: DELETE
-    validate_certs: no
-    headers:
-      Authorization: "bearer {{ kc_auth_response.json.access_token }}"
-    status_code: 204
-    return_content: yes
-  when: kc_auth_response.status == 200 and item.status == 200
-  with_items:
-    - "{{ kc_clients_get_response.results }}"
-
-- name: Get {{ kcdev_username.stdout }} user in realm {{ kc_configmap_realm.stdout }}
-  uri:
-    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/users/{{ item }}"
-    method: GET
-    validate_certs: no
-    headers:
-      Authorization: "bearer {{ kc_auth_response.json.access_token }}"
-    status_code: 200, 404
-    return_content: yes
-  when: kc_auth_response.status == 200
-  register: kc_users_get_response
-  with_items:
-    - "{{ kcdev_userid.stdout }}"
-
 - name: Delete {{ kcdev_username.stdout }} user in realm {{ kc_configmap_realm.stdout }}
   uri:
-    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/users/{{ item.json.id }}"
+    url: "{{ kc_configmap_uri.stdout }}/auth/admin/realms/{{ kc_configmap_realm.stdout }}/users/{{ item }}"
     method: DELETE
     validate_certs: no
     headers:
       Authorization: "bearer {{ kc_auth_response.json.access_token }}"
-    status_code: 204
+    status_code: 204, 404
     return_content: yes
-  when: kc_auth_response.status == 200 and item.status == 200
+  when: kc_auth_response.status == 200
   with_items:
-    - "{{ kc_users_get_response.results }}"
+    - "{{ kcdev_userid.stdout }}"


### PR DESCRIPTION
## Description
Add a check if the public/bearer client created during provision exists first before attempting to delete. A check for the user created during provision is also added to see if it exists before attempting to delete.

## Progress
- [x] Add check if clients created exists before attempting to delete
- [x] Add check if user created exists before attempting to delete

## Additional Notes
**Test Cases**
- Ensure that the Keycloak service can be deleted successfully even when the clients/realm has already been removed.
- Ensure that when 401 and 403 errors are received, it displays a proper error message in the logs.