### PR TITLE
Fix undefined variables bind and unbind errors

### DIFF
--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -19,6 +19,8 @@
     KEYCLOAK_URI: "{{ keycloak_configmap_uri.stdout }}"
     CLIENT_ID: "{{ generated_client_id.stdout }}"
     CLIENT_SECRET: "{{ generated_client_secret.stdout }}"
+
+- set_fact:
     KCADM_REALM: "{{ _apb_provision_creds.IS_SHARED | ternary(KEYCLOAK_REALM,keycloak_admin_realm_name) }}"
 
 - name: Generate keycloak auth token for {{ _apb_provision_creds.USERNAME }}

--- a/roles/provision-keycloak-apb/tasks/addrealmuser-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/addrealmuser-keycloak.yml
@@ -108,6 +108,7 @@
       USERID: "{{ KCDEV_USERID }}"
       USERNAME: "{{ KCDEV_USERNAME }}"
       PASSWORD: "{{ KCDEV_PASSWORD }}"
+      IS_SHARED: "{{ USE_SHARED_SERVICE }}"
 
 - k8s_v1_secret:
     name: '{{ keycloak_secret_name }}'

--- a/roles/unbind-keycloak-apb/tasks/main.yml
+++ b/roles/unbind-keycloak-apb/tasks/main.yml
@@ -5,6 +5,8 @@
 - set_fact:
     KEYCLOAK_REALM: "{{ _apb_bind_creds.bearer_installation.realm }}"
     KEYCLOAK_URI: "{{ keycloak_uri.stdout }}"
+
+- set_fact:
     KCADM_REALM: "{{ _apb_provision_creds.IS_SHARED | ternary(KEYCLOAK_REALM,keycloak_admin_realm_name) }}"
 
 - name: Generate keycloak auth token


### PR DESCRIPTION
## Description
When creating a binding with the Keycloak Service, the bind fails due to `IS_SHARED` field not available in the asb provision credentials. The `KEYCLOAK_REALM` used when registering the value for `KCADM_REALM` is also not found. It's declaration needs to be in a separate `set_fact` task from the declaration of the `KEYCLOAK_REALM` variable.

When deleting the binding, the unbind process fails due to the `KEYCLOAK_REALM` variable, used by the `KCADM_REALM`, is not found. This also needs to be in a separate `set_fact` task from the declaration of the `KEYCLOAK_REALM` variable.

## Progress
- [x] Add `IS_SHARED` variable to the asb provision credentials
- [x] Separate the declaration of the `KCADM_REALM` from the declaration of the the `KEYCLOAK_REALM` variable in the bind process
- [x] Separate the declaration of the `KCADM_REALM` from the declaration of the the `KEYCLOAK_REALM` variable in the unbind process

## Additional Notes
**Errors**
Bind Process: 
> FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'IS_SHARED'...}

> FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'KEYCLOAK_REALM' is undefined...}

Unbind Process:
> FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'KEYCLOAK_REALM' is undefined...}
