### PR TITLE
AEROGEAR-2491 - Don't force the use of the containerised apb tools in Makefile command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ minishift_pull:
 
 .PHONY: apb_build
 apb_build:
-	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:$(APB_TAG) prepare
+	apb prepare
 	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
 
 .PHONY: docker_push
@@ -25,7 +25,7 @@ docker_push:
 
 .PHONY: apb_push
 apb_push:
-	 docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:$(APB_TAG) push
+	apb push
 
 .PHONY: apb_release
 apb_release:
@@ -40,4 +40,3 @@ apb_release:
     else
 				$(error Aborting release process, since local files are modified)
     endif
-

--- a/README.md
+++ b/README.md
@@ -9,33 +9,21 @@
 
 For an overview of what each task does, please check the [APB overview file](./apb_overview.md).
 
-## Requirements
-- [apb](https://github.com/fusor/ansible-playbook-bundle/blob/master/README.md#installing-the-apb-tool)
+## Local Development
 
-**NOTE:**
-Due to our usage of an older version of the ASB, it is recommended using the `apb` CLI like the following:
+### Requirements
 
+- OpenShift Origin [development environment](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/getting_started.md#development-environment) for APB development.
+- Install [apb tool](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md)
+
+### Process
+
+Upload the APB to the local openshift registry (Runs prepare,build,push and relist) [more info](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#push)
 ```bash
-alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools:latest'
+apb push
 ```
 
-Instead of the `abp` alias, you might want to use a modified alias, such as `apb-fh`, to not conflict w/ other versions that might be installed already on your machine.
-
-## Testing
-
-To test changes made locally, after making the changes, run:
-
-```bash
-make apb_build DOCKERORG="<defaulting to aerogearcatalog>" DOCKERHOST="<defaulting to docker.io>"`
-```
-
-If changes were made to the `apb.yml` file, then you will need to execute `apb bootstrap` (if this fails, then you can also run the `~/repos/catasb/local/<os>/reset_environment.sh`), though this takes a little while. Changes to the APB ansible files do not require the above step.
-
-In the Openshift control panel, find and select the `Keycloak (APB)` and fill in the required fields.
-
-You can also test new changes by running `apb test`. What this command does in general is described in [metrics-apb readme](https://github.com/aerogearcatalog/metrics-apb#testing).
-
-For more information about testing of APBs, check [ansible-playbook-bundle documentation](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/getting_started.md#test).
+For more information on APB development and apb command line options, check [ansible-playbook-bundle documentation](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs).
 
 ## Publish
 


### PR DESCRIPTION
Don't force the use of the containerised apb tools in Makefile commands, apb should be installed locally using one of the recommended approaches https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#installing-the-apb-tool