### PR TITLE
🐛 Fix the keycloak pod name selector...

### DIFF
--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -113,7 +113,7 @@
     dest: /tmp/keycloak-metrics-spi-1.0-SNAPSHOT.jar
 
 - name: Get the name of the keycloak pod
-  shell: oc get pods -n '{{ namespace }}' -o jsonpath='{.items[?(@.spec.containers[*].name=="keycloak")].metadata.name}'
+  shell: oc get pods -n '{{ namespace }}' -o jsonpath='{.items[?(@.spec.containers[0].name=="keycloak")].metadata.name}'
   register: keycloak_pod_name
   retries: 10
   until: '"keycloak" in keycloak_pod_name.stdout'


### PR DESCRIPTION
So it doesn't give the below error when there are other pods with more
than 1 container in the namespace

```
error executing jsonpath \"{.items[?(@.spec.containers[*].name==\\\"keycloak\\\")].metadata.name}\": can only compare one element at a time
```

This fix should be OK as long as the keycloak pod doesn't have more than 1 container.
If that changes, we'll have to rethink labelling or something like that to allow easier selecting of the right pod

ping @secondsun @maleck13

related to #48