### PR TITLE
[FIX] Ensure that keycloak realm var is defined during unbind

### DIFF
--- a/roles/unbind-keycloak-apb/tasks/main.yml
+++ b/roles/unbind-keycloak-apb/tasks/main.yml
@@ -9,6 +9,8 @@
 
 - set_fact:
     KEYCLOAK_REALM: "{{ CLIENT_CONFIG.realm }}"
+
+- set_fact:
     KCADM_REALM: "{{ _apb_provision_creds.IS_SHARED | ternary(KEYCLOAK_REALM,keycloak_admin_realm_name) }}"
 
 - name: Generate keycloak auth token


### PR DESCRIPTION
## Description
The unbind process fails due to `keycloak_realm` being undefined when used to set the `kcadm_realm`.  These needs to be separated into two different set fact tasks to ensure that the `keycloak_realm` var is defined before it is used in setting the `kcadm_realm` var.

```
TASK [unbind-keycloak-apb : set_fact] ******************************************
--
  | fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'KEYCLOAK_REALM' is undefined\n\nThe error appears to have been in '/opt/ansible/roles/unbind-keycloak-apb/tasks/main.yml': line 10, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- set_fact:\n  ^ here\n"}
```

## Progress
- [x] Separate setting of `kcadm_realm` var from `keycloak_realm`

## Additional Notes
This is related to this JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-2598
