### PR TITLE
Update bind annotation format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ CiAgICAgIGRlZmF1bHQ6IHB1YmxpYwo="
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
+RUN yum install epel-release -y && yum install jq -y
 RUN ansible-galaxy install -r /opt/apb/actions/requirements.yml -p /opt/ansible/roles
 RUN chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -14,7 +14,12 @@
   shell: "oc get configmaps/{{ keycloak_service_name }} -n {{ namespace }} -o jsonpath={.data.realm}"
   register: keycloak_configmap_realm
 
+- name: Get keycloak service instance name
+  shell: oc get serviceinstances -n {{ namespace }} -o json | jq '.items[] | select(.spec.externalID=="{{ _apb_service_instance_id }}") | .metadata.name'
+  register: keycloak_name
+
 - set_fact:
+    KEYCLOAK_NAME: "{{ keycloak_name.stdout }}"
     KEYCLOAK_REALM: "{{ keycloak_configmap_realm.stdout }}"
     KEYCLOAK_URI: "{{ keycloak_configmap_uri.stdout }}"
     CLIENT_SECRET: "{{ generated_client_secret.stdout }}"
@@ -99,13 +104,17 @@
       uri: "{{ KEYCLOAK_URI }}"
       config: "{{ CLIENT_CONFIG | to_nice_json }}"
 
+- set_fact: 
+    realm_annotation: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/realm"
+    uri_annotation: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/uri"
+   
 # Annotate the mobile client 
 - name: Annotate client {{ CLIENT_ID }}
   shell: "oc annotate mobileclient {{ CLIENT_ID }} {{ item }} -n {{ namespace }}"
   ignore_errors: yes
   with_items:
-    - "{{ keycloak_realm_annotation }}={{ KEYCLOAK_REALM }}"
-    - "{{ keycloak_uri_annotation }}={{ KEYCLOAK_URI }}"
+    - "{{ realm_annotation }}='{label: \"Keycloak Realm\", value: \"{{ KEYCLOAK_REALM }}\", type: \"string\"}'"
+    - "{{ uri_annotation }}='{label: \"Keycloak URL\", value: \"{{ KEYCLOAK_URI }}\", type: \"href\"}'"
     
 - name: Encode {{ CLIENT_ID }} credentials
   asb_encode_binding:

--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -110,7 +110,7 @@
    
 # Annotate the mobile client 
 - name: Annotate client {{ CLIENT_ID }}
-  shell: "oc annotate mobileclient {{ CLIENT_ID }} {{ item }} -n {{ namespace }}"
+  shell: "oc annotate mobileclient {{ CLIENT_ID }} {{ item }} --overwrite=true -n {{ namespace }}"
   ignore_errors: yes
   with_items:
     - "{{ realm_annotation }}='{label: \"Keycloak Realm\", value: \"{{ KEYCLOAK_REALM }}\", type: \"string\"}'"

--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -107,6 +107,7 @@
 - set_fact: 
     realm_annotation: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/realm"
     uri_annotation: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/uri"
+    realm_uri_annotation: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/realm-uri"
    
 # Annotate the mobile client 
 - name: Annotate client {{ CLIENT_ID }}
@@ -115,6 +116,7 @@
   with_items:
     - "{{ realm_annotation }}='{label: \"Keycloak Realm\", value: \"{{ KEYCLOAK_REALM }}\", type: \"string\"}'"
     - "{{ uri_annotation }}='{label: \"Keycloak URL\", value: \"{{ KEYCLOAK_URI }}\", type: \"href\"}'"
+    - "{{ realm_uri_annotation }}='{label: \"Keycloak Realm URL\", value: \"{{ KEYCLOAK_URI }}/auth/admin/master/console/#/realms/{{ KEYCLOAK_REALM }}\", type: \"href\"}'"
     
 - name: Encode {{ CLIENT_ID }} credentials
   asb_encode_binding:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,7 +14,3 @@ keycloak_pv_claim_name: keycloak-metrics
 postgres_pv_claim_name: postgres
 keycloak_admin_realm_name: master
 encode_asb_binding: yes
-
-# Annotations
-keycloak_uri_annotation: binding.aerogear.org/keycloak-uri-href
-keycloak_realm_annotation: binding.aerogear.org/keycloak-realm


### PR DESCRIPTION
**Description** 
Updates the bind playbook with a new format for annotating the mobile client: 

```yaml
org.aerogear.binding.<service-instance-name>/<key>: <value>
``` 
The value is a JSON string with the structure:
```json
{"label": "<display-name>", "type": "[string|href]", "value": "<value>"}
```

e.g.
```yaml
org.aerogear.binding.localregistry-keycloak-apb-7zqk9/realm: '{label: "Keycloak Realm", value: "test", type: "string"}'
org.aerogear.binding.localregistry-keycloak-apb-7zqk9/uri: >-
      {label: "Keycloak URL", value:
      "https://keycloak-test.192.168.42.52.nip.io", type: "href"}
```

**Note**
The `--overwrite` flag is set to true, so new annotations with the same name will be overwritten