### PR TITLE
Update application labels to be unique

### DIFF
--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -18,11 +18,11 @@
     name: 'keycloak-{{ TAG }}'
     namespace: '{{ namespace }}'
     labels:
-      app: keycloak
+      app: '{{ keycloak_service_name }}'
       service: '{{ keycloak_service_name }}'
     replicas: 1
     spec_template_metadata_labels:
-      app: keycloak
+      app: '{{ keycloak_service_name }}'
       name: '{{ keycloak_service_name }}'
     volumes:
     - name: '{{ keycloak_pv_claim_name }}'
@@ -84,7 +84,7 @@
     name: '{{ keycloak_route_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: keycloak
+      app: '{{ keycloak_service_name }}'
       service: '{{ keycloak_service_name }}'
       mobile: enabled
     to_name: '{{ keycloak_service_name }}'
@@ -96,7 +96,7 @@
     name: '{{ keycloak_route_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: keycloak
+      app: '{{ keycloak_service_name }}'
       service: '{{ keycloak_service_name }}'
       mobile: enabled
     tls_termination: edge
@@ -121,7 +121,7 @@
 - debug: var=pods_list
 
 - name: Get the name of the keycloak pod
-  shell: oc get pods -n '{{ namespace }}' -o jsonpath='{.items[?(@.spec.containers[0].name=="keycloak-{{ TAG }}")].metadata.name}'
+  shell: oc get pods -n '{{ namespace }}' -o jsonpath='{.items[?(@.spec.containers[0].name=="{{ keycloak_service_name }}")].metadata.name}'
   register: keycloak_pod_name
   retries: 10
   until: '"keycloak" in keycloak_pod_name.stdout'

--- a/roles/provision-keycloak-apb/tasks/provision-postgres.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-postgres.yml
@@ -48,10 +48,10 @@
     namespace: '{{ namespace }}'
     replicas: 1
     labels:
-      app: keycloak
+      app: '{{ keycloak_service_name }}'
       service: '{{ postgres_service_name }}'
     spec_template_metadata_labels:
-      app: keycloak
+      app: '{{ keycloak_service_name }}'
       name: '{{ postgres_service_name }}'
     containers:
     - name: postgresql

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -1,4 +1,5 @@
 ADMIN_USERNAME: "admin"
 ADMIN_PASSWORD: "admin"
 _apb_service_instance_id: 'dummy_service_instance_id'
+_apb_plan_id: 'default'
 encode_asb_binding: no


### PR DESCRIPTION
Fixes the issue of having a single application (and a single route) for multiple keycloak instances.
(Dockerfile is added because it was out of date)