### PR TITLE
🔥 Remove the need for jq and ansible-galaxy install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ ZWFyZXInLCAncHVibGljJ10KICAgICAgZGVmYXVsdDogcHVibGljCg=="
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
-RUN yum install epel-release -y && yum install jq -y
 RUN ansible-galaxy install -r /opt/apb/actions/requirements.yml -p /opt/ansible/roles
 RUN chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,5 @@ ZWFyZXInLCAncHVibGljJ10KICAgICAgZGVmYXVsdDogcHVibGljCg=="
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
-RUN ansible-galaxy install -r /opt/apb/actions/requirements.yml -p /opt/ansible/roles
 RUN chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,3 +1,0 @@
-- src: https://github.com/aerogear/oc-patch-file-to-configmap-role
-  version: master
-  name: oc-patch-file-to-configmap

--- a/roles/bind-keycloak-apb/tasks/main.yml
+++ b/roles/bind-keycloak-apb/tasks/main.yml
@@ -25,7 +25,7 @@
   register: generated_client_secret
 
 - name: Get keycloak service instance name
-  shell: oc get serviceinstances -n {{ namespace }} -o json | jq '.items[] | select(.spec.externalID=="{{ _apb_service_instance_id }}") | .metadata.name'  | cut -f2 -d'"'
+  shell: oc get serviceinstances -n {{ namespace }} -o jsonpath='{.items[?(@.spec.externalID=="{{ _apb_service_instance_id }}")].metadata.name}'
   register: keycloak_svc_name
 
 - set_fact:
@@ -111,16 +111,16 @@
       name: "{{ keycloak_service_name }}"
       type: "keycloak"
 
-- set_fact: 
+- set_fact:
     REALM_ANNOTATION: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/realm"
     URI_ANNOTATION: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/uri"
     REALM_URI_ANNOTATION: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/realm-uri"
 
-- set_fact: 
+- set_fact:
     PUBLIC_CLIENT_ANNOTATION: "org.aerogear.binding.{{ KEYCLOAK_NAME }}/public-client"
   when: CLIENT_TYPE == "public"
-   
-# Annotate the mobile client 
+
+# Annotate the mobile client
 - name: Annotate client {{ CLIENT_ID }}
   shell: 'oc annotate mobileclient {{ CLIENT_ID }} {{ item }} --overwrite=true -n {{ namespace }}'
   ignore_errors: yes

--- a/roles/oc-patch-file-to-configmap/Readme.md
+++ b/roles/oc-patch-file-to-configmap/Readme.md
@@ -1,0 +1,26 @@
+# oc-patch-file-to-configmap-role
+
+The contents of this dir are a copy of the repo at
+https://github.com/aerogear/oc-patch-file-to-configmap-role at commit
+25d961b37d9c3ddc3fadc9544af785bd781c5bbd
+
+This is a basic Ansible role that can be used to add a JSON file to an existing Openshift Config Map. (using the `oc` CLI tool under the hood).
+
+### Motivation
+
+This role was created for use in the [AeroGear Catalog](https://github.com/organizations/aerogear) Ansible Playbook bundles, specifically to add Grafana Dashboard JSON files as part of a service provision.
+
+### Usage
+
+Inside your APB's `playbooks/provision.yml`:
+
+```yaml
+roles:
+  - role: oc-patch-file-to-configmap
+  file: "{{ lookup('file','/path/to/file.json') }}" # contents of the file
+  filename: "myfile.json" # name the filename will have inside the Config Map
+  configmap: "my-configmap"
+  namespace: "my-project"
+```
+
+You can also take a look at some of the APBs in the [AeroGear Catalog](https://github.com/organizations/aerogear) to see it in action.

--- a/roles/oc-patch-file-to-configmap/tasks/main.yml
+++ b/roles/oc-patch-file-to-configmap/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Check to see if the specified Config Map exists
+  shell: oc get configmap {{ configmap }} -n {{ namespace }}
+  ignore_errors: yes
+  register: check_configmap
+
+- name: Print Warning Message about Config Map not Existing
+  debug:
+    msg: "Warning: Cannot add file {{ filename }} to Config Map {{ configmap }}. Config Map does not exist."
+  when: check_configmap.rc != 0
+
+- block:
+
+  - name: Create appropriate contents from template for 'oc patch' command
+    template:
+      src: oc-patch.json.j2
+      dest: /tmp/oc-patch.json
+
+  - name: Add file to the specified config map
+    shell: oc patch configmap {{ configmap }} -p {{ lookup('file', '/tmp/oc-patch.json') | quote }} -n {{ namespace }}
+    ignore_errors: yes
+    register: oc_patch_result
+
+  - name: Print Debug info about failed oc patch operation
+    debug:
+      var: oc_patch_result
+    when: oc_patch_result.rc != 0
+
+  when: check_configmap.rc == 0

--- a/roles/oc-patch-file-to-configmap/templates/oc-patch.json.j2
+++ b/roles/oc-patch-file-to-configmap/templates/oc-patch.json.j2
@@ -1,0 +1,1 @@
+{"data":{"{{ filename }}": {{ file_contents | to_json | to_json }}}}

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -10,7 +10,7 @@
   register: create_volume_claim
 
 - name: get postgres IP
-  shell: oc get service {{ postgres_service_name }} -n {{ namespace }} -o json | jq ".spec.clusterIP" | cut -f2 -d'"'
+  shell: oc get service {{ postgres_service_name }} -n {{ namespace }} -o jsonpath='{.spec.clusterIP}'
   register: postgresIP
 
 - name: 'create keycloak k8s deployment'


### PR DESCRIPTION
- [ ] To test that everything works without jq, both the install and bind operations should be run.
- [ ] To test that everything works with the bundled role: first make sure the Metrics service is successfully provisioned and running, then provision this. You should be able to see the dedicated keycloak dashboard in Grafana.