### PR TITLE
🐳 Add alternative Dockerfile for RHEL7 

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
-FROM ansibleplaybookbundle/apb-base
+FROM openshift3/apb-base:v3.11
 
-LABEL "com.redhat.apb.version"="0.1.0"
-LABEL "com.redhat.apb.spec"=\
+LABEL com.redhat.component="mobile-identity-management" \
+      com.redhat.apb.spec=\
 "dmVyc2lvbjogMS4wCm5hbWU6IGtleWNsb2FrLWFwYgpkZXNjcmlwdGlvbjogSWRlbnRpdHkgTWFu\
 YWdlbWVudCAtIElkZW50aXR5IGFuZCBBY2Nlc3MgTWFuYWdlbWVudApiaW5kYWJsZTogVHJ1ZQph\
 c3luYzogcmVxdWlyZWQKdGFnczoKICAtIG1vYmlsZS1zZXJ2aWNlCiAgLSBtb2JpbGUtY2xpZW50\
@@ -39,8 +39,15 @@ cnM6CiAgICAtIG5hbWU6IENMSUVOVF9JRAogICAgICByZXF1aXJlZDogVHJ1ZQogICAgICB0aXRs\
 ZTogTW9iaWxlIGNsaWVudCBJRC9TZXJ2aWNlIElECiAgICAgIHR5cGU6IHN0cmluZwogICAgLSBu\
 YW1lOiBDTElFTlRfVFlQRQogICAgICByZXF1aXJlZDogVHJ1ZQogICAgICB0aXRsZTogS2V5Y2xv\
 YWsgY2xpZW50IHR5cGUKICAgICAgdHlwZTogZW51bQogICAgICBlbnVtOiBbJ2JlYXJlcicsICdw\
-dWJsaWMnXQogICAgICBkZWZhdWx0OiBwdWJsaWMK"
-
+dWJsaWMnXQogICAgICBkZWZhdWx0OiBwdWJsaWMK" \
+      name="mobile/mobile-identity-management-apb" \
+      io.k8s.display-name="Mobile Identity Management APB" \
+      io.k8s.description="An APB that deploys Keycloak/RH-SSO on OpenShift through the service catalog, and provides a binding action for mobile use cases" \
+      description="An APB that deploys Keycloak/RH-SSO on OpenShift through the service catalog, and provides a binding action for mobile use cases" \
+      summary="An APB that deploys Keycloak/RH-SSO on OpenShift through the service catalog, and provides a binding action for mobile use cases" \
+      usage="This image is used by the Automation Broker in OpenShift to provision Mobile Identity Management" \
+      maintainer="Red Hat Mobile team" \
+      version="1.0.0"
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles

--- a/apb.yml
+++ b/apb.yml
@@ -3,7 +3,7 @@ name: keycloak-apb
 description: Identity Management - Identity and Access Management
 bindable: True
 async: required
-tags: 
+tags:
   - mobile-service
   - mobile-client-enabled
 metadata:
@@ -11,9 +11,6 @@ metadata:
   imageUrl: "https://pbs.twimg.com/profile_images/702119821979344897/oAC05cEB_400x400.png"
   documentationUrl: "https://docs.aerogear.org/external/apb/keycloak.html"
   providerDisplayName: "Red Hat, Inc."
-  dependencies:
-    - "docker.io/jboss/keycloak-openshift:3.4.3.Final"
-    - "docker.io/centos/postgresql-96-centos7:9.6"
   sdk-docs-android: "https://docs.aerogear.org/external/apb/idm/android.html"
   sdk-docs-cordova: "https://docs.aerogear.org/external/apb/idm/cordova.html"
   sdk-docs-ios: "https://docs.aerogear.org/external/apb/idm/ios.html"
@@ -30,7 +27,7 @@ plans:
       serviceinstance_bind_parameters_data:
         - '{"name": "CLIENT_ID", "value": "metadata.name", "type": "path"}'
         - '{"name": "CLIENT_TYPE", "value": "bearer", "type": "default"}'
-    parameters: 
+    parameters:
     - name: ADMIN_USERNAME
       required: True
       default: admin

--- a/roles/provision-keycloak-apb/defaults/main.yml
+++ b/roles/provision-keycloak-apb/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 playbook_debug: no
+
+keycloak_image: docker.io/jboss/keycloak-openshift
 keycloak_image_tag: 3.4.3.Final
 
-# Non global constants
 postgres_image: docker.io/centos/postgresql-96-centos7
 postgres_image_tag: '9.6'
 postgres_database_name: keycloak

--- a/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
+++ b/roles/provision-keycloak-apb/tasks/provision-keycloak.yml
@@ -55,7 +55,7 @@
         value: "5432"
       - name: POSTGRES_PORT_5432_TCP_ADDR
         value: "{{postgresIP.stdout}}"
-      image: 'docker.io/jboss/keycloak-openshift:{{ keycloak_image_tag }}'
+      image: '{{keycloak_image }}:{{ keycloak_image_tag }}'
       name: '{{ keycloak_service_name }}'
       ports:
       - container_port: 8080


### PR DESCRIPTION
This change also:
- Removes the dependencies section from the apb.yml (we've removed it from the other APBs, as it would be too easy to fall out-of-sync with what's _actually_ being used in the provision playbook.
- Adds a default variable for the `keycloak_image` value, to make it more like the postgres variables in the same file (and more like our other APBs) (and so that there isn't one file to update the image path, and another to update the tag).