### PR TITLE
fix: get rid of deprecation message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ YWsgY2xpZW50IHR5cGUKICAgICAgdHlwZTogZW51bQogICAgICBlbnVtOiBbJ2JlYXJlcicsICdw\
 dWJsaWMnXQogICAgICBkZWZhdWx0OiBwdWJsaWMK"
 
 COPY playbooks /opt/apb/project
+COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
 RUN chmod -R g=u /opt/{ansible,apb}

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -50,6 +50,7 @@ dWJsaWMnXQogICAgICBkZWZhdWx0OiBwdWJsaWMK" \
       version="1.0.0"
 
 COPY playbooks /opt/apb/actions
+COPY playbooks /opt/apb/project
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
 RUN chmod -R g=u /opt/{ansible,apb}


### PR DESCRIPTION
### Motivation
When APB has playbooks copied to `COPY playbooks /opt/apb/actions`, we can see the message about deprecation in apb provisioning pod:
`DEPRECATED: APB playbooks should be stored at /opt/apb/project`

but when the playbooks are copied to suggested directory (`playbooks /opt/apb/project`), some people experienced serious problems with apbs. Provisioning did not work and the provisioning pod fails with `'provision' NOT IMPLEMENTED` message (for some reason, the apb was probably searching for the playbook in the deprecated folder 🤷‍♀️)

By copying the playbooks to both folders, we may avoid the message about deprecation and the fatal error.

@wei-lee, @grdryn if you agree, I will make the same PR for the rest of our APBs